### PR TITLE
test: duplicate subject detection - PASS case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,4 @@ jobs:
         uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate_threshold: '0.8'


### PR DESCRIPTION
## Purpose

Tests the `duplicate_threshold` feature with commits whose subjects are clearly distinct.

## What this tests

- `duplicate_threshold: '0.8'` is enabled in the CI workflow
- All 4 commits have normalized subjects with dice similarity well below 0.8

| Commit | Subject (normalized) |
|---|---|
| `feat: add user authentication module` | `add user authentication module` |
| `fix: resolve session timeout on idle users` | `resolve session timeout on idle users` |
| `docs: update contributing guidelines` | `update contributing guidelines` |

## Expected result

✅ Action **passes** — no duplicate pairs detected