### PR TITLE
test: duplicate subject detection - FAIL case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,4 @@ jobs:
         uses: ./
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate_threshold: '0.8'


### PR DESCRIPTION
## Purpose

Tests the `duplicate_threshold` feature with commits whose subjects are near-identical after normalization.

## What this tests

- `duplicate_threshold: '0.8'` is enabled in the CI workflow
- Two commits share the **same description** with only the type differing → normalized subjects are identical (dice similarity = 1.0 > 0.8)

| Commit | Normalized subject |
|---|---|
| `feat(auth): implement oauth2 login flow` | `implement oauth2 login flow` |
| `fix(auth): implement oauth2 login flow` | `implement oauth2 login flow` |

## Expected result

❌ Action **fails** — 1 duplicate pair detected, PR comment shows the 🔁 Duplicate Commit Subjects section